### PR TITLE
Fix/fluentd: subsystem is hardcoded instead of coming from an environment variable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v0.0.2 / 2022-04-19
+
+### Fluentd-http 
+
+* [CHANGE] Coralogix subsystem is coming from an environment variable, and can be any other kubernetes field. 
+  ([#41](https://github.com/coralogix/eng-integrations/pull/41)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,5 @@
 
 ### Fluentd-http 
 
-* [CHANGE] Coralogix subsystem is coming from an environment variable, and can be any other kubernetes field. 
+* [CHANGE] Enable Coralogix subsystem to be fetched from kuberentes metadata fields.  
   ([#41](https://github.com/coralogix/eng-integrations/pull/41)).

--- a/fluentd/http/Chart.yaml
+++ b/fluentd/http/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluentd-http
 description: Fluentd Chart with HTTP output plugin
-version: 0.0.1
+version: 0.0.2
 appVersion: v1.12.0
 keywords:
   - Fluentd

--- a/fluentd/http/values.yaml
+++ b/fluentd/http/values.yaml
@@ -25,9 +25,9 @@ fluentd:
 
   env:
   - name: APP_NAME
-    value: $kubernetes.namespace_name
+    value: namespace_name
   - name: SUB_SYSTEM
-    value: $kubernetes.container_name
+    value: container_name
   - name: APP_NAME_SYSTEMD
     value: systemd
   - name: SUB_SYSTEM_SYSTEMD
@@ -132,7 +132,7 @@ fluentd:
         <record>
           privateKey "#{ENV['PRIVATE_KEY']}"
           applicationName ${record.dig("kubernetes", "#{ENV['APP_NAME']}")}
-          subsystemName ${record.dig("kubernetes", "container_name")}
+          subsystemName ${record.dig("kubernetes", "#{ENV['SUB_SYSTEM']}")}
           computerName ${record.dig("kubernetes", "host")}
           timestamp ${time.strftime('%s%L')}
           text ${record.to_json}

--- a/fluentd/http/values.yaml
+++ b/fluentd/http/values.yaml
@@ -25,7 +25,7 @@ fluentd:
 
   env:
   - name: APP_NAME
-    value: namespace_name
+    value: $kubernetes.namespace_name
   - name: SUB_SYSTEM
     value: $kubernetes.container_name
   - name: APP_NAME_SYSTEMD


### PR DESCRIPTION
### FIX: fluent-bit-http chart 
Currently the subsystem name is configured to be `kubernetes.container_name` and doesnt allow any changes. 
Changing the subsystem kubernetes field to `come from an env`, allowing it to be override.  