### PR TITLE
Generating integrations manifests from github workflows for manual de…

### DIFF
--- a/.github/workflows/fluent-bit-http-chart.yml
+++ b/.github/workflows/fluent-bit-http-chart.yml
@@ -45,5 +45,5 @@ jobs:
           cd ${{ env.CXINTEGRATIONS_CLI_PATH }}
           ./cx-integrations generate ${{ env.CHART_NAME }} --outputdir manifests
           git add ./manifests/${{ env.CHART_NAME }}-manifests.yaml 
-          git commit -m "Update fluentd-http manifests for manual deploy"
+          git commit -m "Update fluent-bit-http manifests for manual deploy"
           git push

--- a/.github/workflows/fluent-bit-http-chart.yml
+++ b/.github/workflows/fluent-bit-http-chart.yml
@@ -12,6 +12,7 @@ env:
   CHART_NAME: fluent-bit-http
   ARTIFACTORY_URL: https://cgx.jfrog.io/artifactory/
   ARTIFACTORY_USERNAME: integrations-actions
+  CXINTEGRATIONS_CLI_PATH: cxtool
 
 jobs:
   build:
@@ -38,3 +39,9 @@ jobs:
         run: |
           cd fluent-bit/http
           jfrog rt upload --access-token ${{ secrets.ARTIFACTORY_NONUSER_ACCESS_TOKEN }} "${{ env.CHART_NAME }}-*.tgz" coralogix-charts --url ${{ env.ARTIFACTORY_URL }}
+      -
+        name: Generate Integrations Manifests
+        run: |
+          cd ${{ env.CXINTEGRATIONS_CLI_PATH }}
+          ./cx-integrations generate ${{ env.CHART_NAME }} --output-dir manual-manifests/${{ env.CHART_NAME }}
+ 

--- a/.github/workflows/fluent-bit-http-chart.yml
+++ b/.github/workflows/fluent-bit-http-chart.yml
@@ -44,4 +44,3 @@ jobs:
         run: |
           cd ${{ env.CXINTEGRATIONS_CLI_PATH }}
           ./cx-integrations generate ${{ env.CHART_NAME }} --output-dir manual-manifests/${{ env.CHART_NAME }}
- 

--- a/.github/workflows/fluent-bit-http-chart.yml
+++ b/.github/workflows/fluent-bit-http-chart.yml
@@ -43,4 +43,4 @@ jobs:
         name: Generate Integrations Manifests
         run: |
           cd ${{ env.CXINTEGRATIONS_CLI_PATH }}
-          ./cx-integrations generate ${{ env.CHART_NAME }} --output-dir manual-manifests/${{ env.CHART_NAME }}
+          ./cx-integrations generate ${{ env.CHART_NAME }} --output-dir integrations-manifests/${{ env.CHART_NAME }}

--- a/.github/workflows/fluent-bit-http-chart.yml
+++ b/.github/workflows/fluent-bit-http-chart.yml
@@ -43,4 +43,7 @@ jobs:
         name: Generate Integrations Manifests
         run: |
           cd ${{ env.CXINTEGRATIONS_CLI_PATH }}
-          ./cx-integrations generate ${{ env.CHART_NAME }} --output-dir integrations-manifests/${{ env.CHART_NAME }}
+          ./cx-integrations generate ${{ env.CHART_NAME }}
+          git add ./output/${{ env.CHART_NAME }}-manifests.yaml 
+          git commit -m "Update fluentd-http manifests for manual deploy"
+          git push

--- a/.github/workflows/fluent-bit-http-chart.yml
+++ b/.github/workflows/fluent-bit-http-chart.yml
@@ -43,7 +43,7 @@ jobs:
         name: Generate Integrations Manifests
         run: |
           cd ${{ env.CXINTEGRATIONS_CLI_PATH }}
-          ./cx-integrations generate ${{ env.CHART_NAME }}
-          git add ./output/${{ env.CHART_NAME }}-manifests.yaml 
+          ./cx-integrations generate ${{ env.CHART_NAME }} --outputdir manifests
+          git add ./manifests/${{ env.CHART_NAME }}-manifests.yaml 
           git commit -m "Update fluentd-http manifests for manual deploy"
           git push

--- a/.github/workflows/fluentd-http-chart.yml
+++ b/.github/workflows/fluentd-http-chart.yml
@@ -12,7 +12,7 @@ env:
   CHART_NAME: fluentd-http
   ARTIFACTORY_URL: https://cgx.jfrog.io/artifactory/
   ARTIFACTORY_USERNAME: integrations-actions
-
+  CXINTEGRATIONS_CLI_PATH: cxtool
 
 jobs:
   build:
@@ -38,5 +38,9 @@ jobs:
         name: use-jfrog-cli
         run: |
           cd fluentd/http
-          jfrog rt upload --access-token ${{ secrets.ARTIFACTORY_NONUSER_ACCESS_TOKEN }} "${{ env.CHART_NAME }}-*.tgz" coralogix-charts --url ${{ env.ARTIFACTORY_URL }}
-          
+          jfrog rt upload --access-token ${{ secrets.ARTIFACTORY_NONUSER_ACCESS_TOKEN }} "${{ env.CHART_NAME }}-*.tgz" coralogix-charts --url ${{ env.ARTIFACTORY_URL }}    
+      -
+        name: Generate Integrations Manifests
+        run: |
+          cd ${{ env.CXINTEGRATIONS_CLI_PATH }}
+          ./cx-integrations generate ${{ env.CHART_NAME }} --output-dir manual-manifests/${{ env.CHART_NAME }}

--- a/.github/workflows/fluentd-http-chart.yml
+++ b/.github/workflows/fluentd-http-chart.yml
@@ -43,4 +43,4 @@ jobs:
         name: Generate Integrations Manifests
         run: |
           cd ${{ env.CXINTEGRATIONS_CLI_PATH }}
-          ./cx-integrations generate ${{ env.CHART_NAME }} --output-dir manual-manifests/${{ env.CHART_NAME }}
+          ./cx-integrations generate ${{ env.CHART_NAME }} --output-dir integrations-manifests/${{ env.CHART_NAME }}

--- a/.github/workflows/fluentd-http-chart.yml
+++ b/.github/workflows/fluentd-http-chart.yml
@@ -43,4 +43,7 @@ jobs:
         name: Generate Integrations Manifests
         run: |
           cd ${{ env.CXINTEGRATIONS_CLI_PATH }}
-          ./cx-integrations generate ${{ env.CHART_NAME }} --output-dir integrations-manifests/${{ env.CHART_NAME }}
+          ./cx-integrations generate ${{ env.CHART_NAME }}
+          git add ./output/${{ env.CHART_NAME }}-manifests.yaml 
+          git commit -m "Update fluentd-http manifests for manual deploy"
+          git push

--- a/.github/workflows/fluentd-http-chart.yml
+++ b/.github/workflows/fluentd-http-chart.yml
@@ -43,7 +43,7 @@ jobs:
         name: Generate Integrations Manifests
         run: |
           cd ${{ env.CXINTEGRATIONS_CLI_PATH }}
-          ./cx-integrations generate ${{ env.CHART_NAME }}
-          git add ./output/${{ env.CHART_NAME }}-manifests.yaml 
+          ./cx-integrations generate ${{ env.CHART_NAME }} --outputdir manifests
+          git add ./manifests/${{ env.CHART_NAME }}-manifests.yaml 
           git commit -m "Update fluentd-http manifests for manual deploy"
           git push


### PR DESCRIPTION
As part of the GitHub Actions worfklows runs,
the desired `integration's manifests will be generated` using the CX-Integrations CLI,
and will be saved under 'manifests/<integration-name>-manifests.yaml'. 

* By adding the generation of the yamls inside the workflows, we can be sure we always have the most updated yamls that match the last release.

* The generated yamls are only for 'fluentd-http' and 'fluent-bit-http' since the CLI supports only these two. The Coralogix integrations are going to be deprecated, therefore it's not supported here. 