### PR TITLE
FIX: fluentd buffer configuration and fluentbit set retry no limit, c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Changelog
 
-### Fluentd-http
+## Fluentd-http
 
-## v0.0.2 / 2022-04-19
+### v0.0.2 / 2022-04-19
 
 * [CHANGE] Enable Coralogix subsystem to be fetched from kuberentes metadata fields
   ([#41](https://github.com/coralogix/eng-integrations/pull/41))
 
-## v0.0.3 / 2022-04-26
+### v0.0.3 / 2022-04-26
 
 * [CHANGE] Set default logLevel to error 
 * [CHANGE] Set buffer overflow_action to 'throw_exception' instead of 'block'
 * [CHANGE] Set flush_thread_count to 4 for parallelism of the outputs
 
-### Fluent-Bit
+## Fluent-Bit
 
-## v0.0.2 / 2022-04-26
+### v0.0.2 / 2022-04-26
 
 * [CHANGE] Set Retry_Limit to False [no limit] to keep retrying send the logs and not lose any data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 ## Fluentd-http
 
-### v0.0.2 / 2022-04-19
-
-* [CHANGE] Enable Coralogix subsystem to be fetched from kuberentes metadata fields
-  ([#41](https://github.com/coralogix/eng-integrations/pull/41))
-
 ### v0.0.3 / 2022-04-26
 
 * [CHANGE] Set default logLevel to error 
 * [CHANGE] Set buffer overflow_action to 'throw_exception' instead of 'block'
 * [CHANGE] Set flush_thread_count to 4 for parallelism of the outputs
   ([#48](https://github.com/coralogix/eng-integrations/pull/48))
+
+### v0.0.2 / 2022-04-19
+
+* [CHANGE] Enable Coralogix subsystem to be fetched from kuberentes metadata fields
+  ([#41](https://github.com/coralogix/eng-integrations/pull/41))
 
 ## Fluent-Bit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@
 * [CHANGE] Set default logLevel to error 
 * [CHANGE] Set buffer overflow_action to 'throw_exception' instead of 'block'
 * [CHANGE] Set flush_thread_count to 4 for parallelism of the outputs
+  ([#48](https://github.com/coralogix/eng-integrations/pull/48))
 
 ## Fluent-Bit
 
 ### v0.0.2 / 2022-04-26
 
 * [CHANGE] Set Retry_Limit to False [no limit] to keep retrying send the logs and not lose any data
+  ([#48](https://github.com/coralogix/eng-integrations/pull/48))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Changelog
 
+### Fluentd-http
+
 ## v0.0.2 / 2022-04-19
 
-### Fluentd-http 
+* [CHANGE] Enable Coralogix subsystem to be fetched from kuberentes metadata fields
+  ([#41](https://github.com/coralogix/eng-integrations/pull/41))
 
-* [CHANGE] Enable Coralogix subsystem to be fetched from kuberentes metadata fields.  
-  ([#41](https://github.com/coralogix/eng-integrations/pull/41)).
+## v0.0.3 / 2022-04-26
+
+* [CHANGE] Set default logLevel to error 
+* [CHANGE] Set buffer overflow_action to 'throw_exception' instead of 'block'
+* [CHANGE] Set flush_thread_count to 4 for parallelism of the outputs
+
+### Fluent-Bit
+
+## v0.0.2 / 2022-04-26
+
+* [CHANGE] Set Retry_Limit to False [no limit] to keep retrying send the logs and not lose any data

--- a/fluent-bit/coralogix/Chart.yaml
+++ b/fluent-bit/coralogix/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluent-bit-coralogix
 description: Fluent-Bit Chart with Coralogix output plugin
-version: 0.0.1
+version: 0.0.2
 appVersion: 1.8.10
 keywords:
   - Fluent-Bit

--- a/fluent-bit/coralogix/README.md
+++ b/fluent-bit/coralogix/README.md
@@ -59,8 +59,6 @@ helm upgrade fluent-bit-coralogix coralogix-charts-virtual/fluent-bit-coralogix 
 | EU2     | `api.eu2.coralogix.com`                  |
 | US      | `api.coralogix.us`                       |
 | SG      | `api.coralogixsg.com`                    |
-| EUROPE1 | `tracing-ingress.coralogix.com:9443`     |
-| EUROPE2 | `tracing-ingress.eu2.coralogix.com:9443` |
 | IN      | `api.app.coralogix.in`                   |
 
 **NOTE**

--- a/fluent-bit/coralogix/README.md
+++ b/fluent-bit/coralogix/README.md
@@ -51,6 +51,18 @@ helm upgrade fluent-bit-coralogix coralogix-charts-virtual/fluent-bit-coralogix 
   -f override-fluentbit-coralogix.yaml
 ```
 
+## Coralogix Endpoints
+
+| Region  | Logs Endpoint
+|---------|------------------------------------------|
+| EU      | `api.coralogix.com`                      |
+| EU2     | `api.eu2.coralogix.com`                  |
+| US      | `api.coralogix.us`                       |
+| SG      | `api.coralogixsg.com`                    |
+| EUROPE1 | `tracing-ingress.coralogix.com:9443`     |
+| EUROPE2 | `tracing-ingress.eu2.coralogix.com:9443` |
+| IN      | `api.app.coralogix.in`                   |
+
 **NOTE**
 We suggest using dynamic app_name and sub_system, since it's more agile than using static values.
 

--- a/fluent-bit/coralogix/values.yaml
+++ b/fluent-bit/coralogix/values.yaml
@@ -85,7 +85,7 @@ fluent-bit:
   endpoint: api.eu2.coralogix.com
   app_name:  kubernetes.namespace_name
   sub_system: kubernetes.container_name
-  logLevel: info
+  logLevel: error
 
   config:
 

--- a/fluent-bit/http/Chart.yaml
+++ b/fluent-bit/http/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluent-bit-http
 description: Fluent-Bit Chart with HTTP output plugin
-version: 0.0.1
+version: 0.0.2
 appVersion: 1.8.10
 keywords:
   - Fluent-Bit

--- a/fluent-bit/http/README.md
+++ b/fluent-bit/http/README.md
@@ -73,6 +73,18 @@ helm upgrade fluent-bit-http coralogix-charts-virtual/fluent-bit-http \
   -f override-fluentbit-http.yaml
 ```
 
+## Coralogix Endpoints
+
+| Region  | Logs Endpoint
+|---------|------------------------------------------|
+| EU      | `api.coralogix.com`                      |
+| EU2     | `api.eu2.coralogix.com`                  |
+| US      | `api.coralogix.us`                       |
+| SG      | `api.coralogixsg.com`                    |
+| EUROPE1 | `tracing-ingress.coralogix.com:9443`     |
+| EUROPE2 | `tracing-ingress.eu2.coralogix.com:9443` |
+| IN      | `api.app.coralogix.in`                   |
+
 **NOTE**
 We suggest using dynamic app_name and sub_system, since it's more agile than using static values.
 

--- a/fluent-bit/http/README.md
+++ b/fluent-bit/http/README.md
@@ -81,8 +81,6 @@ helm upgrade fluent-bit-http coralogix-charts-virtual/fluent-bit-http \
 | EU2     | `api.eu2.coralogix.com`                  |
 | US      | `api.coralogix.us`                       |
 | SG      | `api.coralogixsg.com`                    |
-| EUROPE1 | `tracing-ingress.coralogix.com:9443`     |
-| EUROPE2 | `tracing-ingress.eu2.coralogix.com:9443` |
 | IN      | `api.app.coralogix.in`                   |
 
 **NOTE**

--- a/fluent-bit/http/values.yaml
+++ b/fluent-bit/http/values.yaml
@@ -85,7 +85,7 @@ fluent-bit:
   endpoint: api.eu2.coralogix.com
   app_name: kubernetes.namespace_name
   sub_system: kubernetes.container_name
-  logLevel: info
+  logLevel: error
 
   config: 
     service: |-
@@ -173,7 +173,7 @@ fluent-bit:
           TLS                   On
           Header                private_key ${PRIVATE_KEY}
           compress              gzip
-          Retry_Limit           10
+          Retry_Limit           False
 
       @INCLUDE output-systemd.conf
     

--- a/fluentd/coralogix/Chart.yaml
+++ b/fluentd/coralogix/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluentd-coralogix
 description: Fluentd Chart with Coralogix output plugin
-version: 0.0.1
+version: 0.0.2
 appVersion: v1.12.0
 keywords:
   - Fluentd

--- a/fluentd/coralogix/README.md
+++ b/fluentd/coralogix/README.md
@@ -67,8 +67,6 @@ fluentd:
     # - fluentd-systemd-conf
 ```
 
-* For override.yaml examples, please see: [fluentd override examples](https://github.com/coralogix/eng-integrations/blob/master/fluentd/examples)
-
 ## Dashboard
 Under the `dashboard` directory, there is a Fluentd Grafana dashboard that Coralogix supplies.
 In order to import the dashboard into Grafana, firstly copy the json file content.

--- a/fluentd/coralogix/README.md
+++ b/fluentd/coralogix/README.md
@@ -24,7 +24,7 @@ fluentd:
   - name: SUB_SYSTEM_SYSTEMD
     value: kubelet.service
   - name: ENDPOINT
-    value: <[put_your_coralogix_endpoint_here](https://github.com/coralogix/eng-integrations/blob/master/fluentd/coralogix/README.md#coralogix-endpoints)>
+    value: <put_your_coralogix_endpoint_here>
   - name: "FLUENTD_CONF"
     value: "../../etc/fluent/fluent.conf"
   - name: LOG_LEVEL

--- a/fluentd/coralogix/README.md
+++ b/fluentd/coralogix/README.md
@@ -16,21 +16,21 @@ In order to update the environment variables, please create a new yaml file and 
 fluentd:
   env:
   - name: APP_NAME
-    value: <app_name>
+    value: namespace_name
   - name: SUB_SYSTEM
-    value: <sub_system>
+    value: container_name
   - name: APP_NAME_SYSTEMD
     value: systemd
   - name: SUB_SYSTEM_SYSTEMD
     value: kubelet.service
   - name: ENDPOINT
-    value: <coralogix_endpoint>
+    value: <put_your_coralogix_endpoint_here>
   - name: "FLUENTD_CONF"
     value: "../../etc/fluent/fluent.conf"
   - name: LOG_LEVEL
-    value: <level>
+    value: error
   - name: MAX_LOG_BUFFER_SIZE
-    value: <max_log_buffer_size>
+    value: "12582912"
   - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
@@ -43,6 +43,18 @@ helm upgrade fluentd-coralogix coralogix-charts-virtual/fluentd-coralogix \
   --create-namespace \
   -f override.yaml
 ```
+
+## Coralogix Endpoints
+
+| Region  | Logs Endpoint
+|---------|------------------------------------------|
+| EU      | `api.coralogix.com`                      |
+| EU2     | `api.eu2.coralogix.com`                  |
+| US      | `api.coralogix.us`                       |
+| SG      | `api.coralogixsg.com`                    |
+| EUROPE1 | `tracing-ingress.coralogix.com:9443`     |
+| EUROPE2 | `tracing-ingress.eu2.coralogix.com:9443` |
+| IN      | `api.app.coralogix.in`                   |
 
 ## Disable Systemd Logs
 In order to disable the systemd logs, please create a new yaml file or edit your existing override.yaml that includes the environment varibales, and comment out the fluentd-system-conf line:

--- a/fluentd/coralogix/README.md
+++ b/fluentd/coralogix/README.md
@@ -24,7 +24,7 @@ fluentd:
   - name: SUB_SYSTEM_SYSTEMD
     value: kubelet.service
   - name: ENDPOINT
-    value: <put_your_coralogix_endpoint_here>
+    value: <[put_your_coralogix_endpoint_here](https://github.com/coralogix/eng-integrations/blob/master/fluentd/coralogix/README.md#coralogix-endpoints)>
   - name: "FLUENTD_CONF"
     value: "../../etc/fluent/fluent.conf"
   - name: LOG_LEVEL

--- a/fluentd/coralogix/README.md
+++ b/fluentd/coralogix/README.md
@@ -52,8 +52,6 @@ helm upgrade fluentd-coralogix coralogix-charts-virtual/fluentd-coralogix \
 | EU2     | `api.eu2.coralogix.com`                  |
 | US      | `api.coralogix.us`                       |
 | SG      | `api.coralogixsg.com`                    |
-| EUROPE1 | `tracing-ingress.coralogix.com:9443`     |
-| EUROPE2 | `tracing-ingress.eu2.coralogix.com:9443` |
 | IN      | `api.app.coralogix.in`                   |
 
 ## Disable Systemd Logs

--- a/fluentd/coralogix/values.yaml
+++ b/fluentd/coralogix/values.yaml
@@ -37,7 +37,7 @@ fluentd:
   - name: "FLUENTD_CONF"
     value: "../../etc/fluent/fluent.conf"
   - name: LOG_LEVEL
-    value: info
+    value: error
   - name: MAX_LOG_BUFFER_SIZE
     value: "12582912"
   - name: K8S_NODE_NAME

--- a/fluentd/docs/coralogix-alerts.md
+++ b/fluentd/docs/coralogix-alerts.md
@@ -1,0 +1,55 @@
+## Coralogix Fluentd Buffer Alert
+
+Fluentd uses memory to store buffer chunks, once its buffer is full, it starts throwing exceptions in its logs,
+and it means there is a bottleneck, the Fluentd cant tail new logs.
+Therefore we recommend creating an alert in Coralogix, that will trigger while Fluentd starts throwing buffer exceptions,
+Run the following command in order to create a new alert in Coralogix: 
+** `Alerts, Rules and Tags API Key` needs to be inserted in the command
+** Notifications emails and integrations need to be updated 
+
+```
+curl -X POST https://api.eu2.coralogix.com/api/v1/external/alerts -H "Authorization: bearer <Alerts, Rules and Tags API Key>" -H "Content-Type: application/json" --data-binary '{
+        "name": "Fluentd Buffer Full",
+        "severity": "critical",
+        "is_active": true,
+        "log_filter": {
+                "text": "BufferOverflow",
+                "category": null,
+                "filter_type": "text",
+                "severity": ["error", "critical"],
+                "application_name": ["default"],
+                "subsystem_name": ["fluentd"],
+                "computer_name": null,
+                "class_name": null,
+                "ip_address": null,
+                "method_name": null
+        },
+        "condition": {
+                "condition_type": "more_than",
+                "threshold": 3,
+                "timeframe": "5MIN",
+                "group_by": "host"
+        },
+        "notifications": {
+                "emails": ["security@mycompany.com", "mgmt@mycompany.com"],
+                "integrations": ["myintegration"]
+        },
+        "notify_every": 60,
+        "description": "Fluentd buffer is full, destination capacity is insufficient for your traffic.",
+        "active_when": {
+                "timeframes": [{
+                        "days_of_week": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6
+                        ],
+                        "activity_ends": "00:00:00",
+                        "activity_starts": "00:00:01"
+                }]
+        }
+}'
+```

--- a/fluentd/http/Chart.yaml
+++ b/fluentd/http/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluentd-http
 description: Fluentd Chart with HTTP output plugin
-version: 0.0.2
+version: 0.0.3
 appVersion: v1.12.0
 keywords:
   - Fluentd

--- a/fluentd/http/README.md
+++ b/fluentd/http/README.md
@@ -24,7 +24,7 @@ fluentd:
   - name: SUB_SYSTEM_SYSTEMD
     value: kubelet.service
   - name: ENDPOINT
-    value: api.eu2.coralogix.com
+    value: <put_your_coralogix_endpoint_here>
   - name: "FLUENTD_CONF"
     value: "../../etc/fluent/fluent.conf"
   - name: LOG_LEVEL
@@ -41,6 +41,18 @@ helm upgrade fluentd-http coralogix-charts-virtual/fluentd-http \
   --create-namespace \
   -f override.yaml
 ```
+
+## Coralogix Endpoints
+
+| Region  | Logs Endpoint
+|---------|------------------------------------------|
+| EU      | `api.coralogix.com`                      |
+| EU2     | `api.eu2.coralogix.com`                  |
+| US      | `api.coralogix.us`                       |
+| SG      | `api.coralogixsg.com`                    |
+| EUROPE1 | `tracing-ingress.coralogix.com:9443`     |
+| EUROPE2 | `tracing-ingress.eu2.coralogix.com:9443` |
+| IN      | `api.app.coralogix.in`                   |
 
 ## Disable Systemd Logs
 In order to disable the systemd logs, please create a new yaml file or edit your existing override.yaml that includes the environment varibales, and comment out the fluentd-system-conf line:

--- a/fluentd/http/README.md
+++ b/fluentd/http/README.md
@@ -24,7 +24,7 @@ fluentd:
   - name: SUB_SYSTEM_SYSTEMD
     value: kubelet.service
   - name: ENDPOINT
-    value: <[put_your_coralogix_endpoint_here](https://github.com/coralogix/eng-integrations/blob/master/fluentd/http/README.md#coralogix-endpoints)>
+    value: <put_your_coralogix_endpoint_here>
   - name: "FLUENTD_CONF"
     value: "../../etc/fluent/fluent.conf"
   - name: LOG_LEVEL

--- a/fluentd/http/README.md
+++ b/fluentd/http/README.md
@@ -63,3 +63,58 @@ Afterwards go to Grafana press the `Create` tab, then press `import`, and paste 
 ## Dependencies
 By default this chart installs additional dependent chart:
 (https://github.com/fluent/helm-charts/tree/main/charts/fluentd)
+
+## Coralogix Fluentd Buffer Alert
+Fluentd uses memory to store buffer chunks, once its buffer is full, it starts throwing exceptions in its logs,
+and it means there is a bottleneck, the Fluentd cant tail new logs.
+Therefore we recommend creating an alert in Coralogix, that will trigger while Fluentd starts throwing buffer exceptions,
+Run the following command in order to create a new alert in Coralogix: 
+** `Alerts, Rules and Tags API Key` needs to be inserted in the command
+** Notifications emails and integrations need to be updated 
+
+```
+curl -X POST https://api.eu2.coralogix.com/api/v1/external/alerts -H "Authorization: bearer <Alerts, Rules and Tags API Key>" -H "Content-Type: application/json" --data-binary '{
+        "name": "Fluentd Buffer Full",
+        "severity": "critical",
+        "is_active": true,
+        "log_filter": {
+                "text": "BufferOverflow",
+                "category": null,
+                "filter_type": "text",
+                "severity": ["error", "critical"],
+                "application_name": ["default"],
+                "subsystem_name": ["fluentd"],
+                "computer_name": null,
+                "class_name": null,
+                "ip_address": null,
+                "method_name": null
+        },
+        "condition": {
+                "condition_type": "more_than",
+                "threshold": 3,
+                "timeframe": "5MIN",
+                "group_by": "host"
+        },
+        "notifications": {
+                "emails": ["security@mycompany.com", "mgmt@mycompany.com"],
+                "integrations": ["myintegration"]
+        },
+        "notify_every": 60,
+        "description": "Fluentd buffer is full, destination capacity is insufficient for your traffic.",
+        "active_when": {
+                "timeframes": [{
+                        "days_of_week": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6
+                        ],
+                        "activity_ends": "00:00:00",
+                        "activity_starts": "00:00:01"
+                }]
+        }
+}'
+```

--- a/fluentd/http/README.md
+++ b/fluentd/http/README.md
@@ -16,19 +16,19 @@ In order to update the environment variables, please create a new yaml file and 
 fluentd:
   env:
   - name: APP_NAME
-    value: <app_name>
+    value: namespace_name
   - name: SUB_SYSTEM
-    value: <sub_system>
+    value: container_name
   - name: APP_NAME_SYSTEMD
     value: systemd
   - name: SUB_SYSTEM_SYSTEMD
     value: kubelet.service
   - name: ENDPOINT
-    value: <coralogix_endpoint>
+    value: api.eu2.coralogix.com
   - name: "FLUENTD_CONF"
     value: "../../etc/fluent/fluent.conf"
   - name: LOG_LEVEL
-    value: <level>
+    value: error
   - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:

--- a/fluentd/http/README.md
+++ b/fluentd/http/README.md
@@ -50,8 +50,6 @@ helm upgrade fluentd-http coralogix-charts-virtual/fluentd-http \
 | EU2     | `api.eu2.coralogix.com`                  |
 | US      | `api.coralogix.us`                       |
 | SG      | `api.coralogixsg.com`                    |
-| EUROPE1 | `tracing-ingress.coralogix.com:9443`     |
-| EUROPE2 | `tracing-ingress.eu2.coralogix.com:9443` |
 | IN      | `api.app.coralogix.in`                   |
 
 ## Disable Systemd Logs

--- a/fluentd/http/README.md
+++ b/fluentd/http/README.md
@@ -65,8 +65,6 @@ fluentd:
     # - fluentd-systemd-conf
 ```
 
-* For override.yaml examples, please see: [fluentd override examples](https://github.com/coralogix/eng-integrations/blob/master/fluentd/examples)
-
 ## Dashboard
 Under the `dashboard` directory, there is a Fluentd Grafana dashboard that Coralogix supplies.
 In order to import the dashboard into Grafana, firstly copy the json file content.
@@ -77,56 +75,4 @@ By default this chart installs additional dependent chart:
 (https://github.com/fluent/helm-charts/tree/main/charts/fluentd)
 
 ## Coralogix Fluentd Buffer Alert
-Fluentd uses memory to store buffer chunks, once its buffer is full, it starts throwing exceptions in its logs,
-and it means there is a bottleneck, the Fluentd cant tail new logs.
-Therefore we recommend creating an alert in Coralogix, that will trigger while Fluentd starts throwing buffer exceptions,
-Run the following command in order to create a new alert in Coralogix: 
-** `Alerts, Rules and Tags API Key` needs to be inserted in the command
-** Notifications emails and integrations need to be updated 
-
-```
-curl -X POST https://api.eu2.coralogix.com/api/v1/external/alerts -H "Authorization: bearer <Alerts, Rules and Tags API Key>" -H "Content-Type: application/json" --data-binary '{
-        "name": "Fluentd Buffer Full",
-        "severity": "critical",
-        "is_active": true,
-        "log_filter": {
-                "text": "BufferOverflow",
-                "category": null,
-                "filter_type": "text",
-                "severity": ["error", "critical"],
-                "application_name": ["default"],
-                "subsystem_name": ["fluentd"],
-                "computer_name": null,
-                "class_name": null,
-                "ip_address": null,
-                "method_name": null
-        },
-        "condition": {
-                "condition_type": "more_than",
-                "threshold": 3,
-                "timeframe": "5MIN",
-                "group_by": "host"
-        },
-        "notifications": {
-                "emails": ["security@mycompany.com", "mgmt@mycompany.com"],
-                "integrations": ["myintegration"]
-        },
-        "notify_every": 60,
-        "description": "Fluentd buffer is full, destination capacity is insufficient for your traffic.",
-        "active_when": {
-                "timeframes": [{
-                        "days_of_week": [
-                                0,
-                                1,
-                                2,
-                                3,
-                                4,
-                                5,
-                                6
-                        ],
-                        "activity_ends": "00:00:00",
-                        "activity_starts": "00:00:01"
-                }]
-        }
-}'
-```
+In order to create an alert on Fluentd buffer in Coralogix, please see [coralogix-alert doc](https://github.com/coralogix/eng-integrations/blob/master/fluentd/docs/coralogix-alerts.md) 

--- a/fluentd/http/README.md
+++ b/fluentd/http/README.md
@@ -24,7 +24,7 @@ fluentd:
   - name: SUB_SYSTEM_SYSTEMD
     value: kubelet.service
   - name: ENDPOINT
-    value: <put_your_coralogix_endpoint_here>
+    value: <[put_your_coralogix_endpoint_here](https://github.com/coralogix/eng-integrations/blob/master/fluentd/http/README.md#coralogix-endpoints)>
   - name: "FLUENTD_CONF"
     value: "../../etc/fluent/fluent.conf"
   - name: LOG_LEVEL

--- a/fluentd/http/values.yaml
+++ b/fluentd/http/values.yaml
@@ -32,12 +32,12 @@ fluentd:
     value: systemd
   - name: SUB_SYSTEM_SYSTEMD
     value: kubelet.service
-  - name: ENDPOINT   
+  - name: ENDPOINT
     value: api.eu2.coralogix.com
   - name: "FLUENTD_CONF"
     value: "../../etc/fluent/fluent.conf"
   - name: LOG_LEVEL
-    value: info
+    value: error
   - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
@@ -174,9 +174,10 @@ fluentd:
           error_response_as_unrecoverable false
           <buffer $.privateKey>
             @type memory
+            flush_thread_count 4
             chunk_limit_size 10MB
             flush_interval 1s
-            overflow_action block
+            overflow_action throw_exception
             retry_max_times 10
             retry_type periodic
             retry_wait 8


### PR DESCRIPTION
## Fixes and Updates:

* set `logLevel` on 'error' instead of 'info' in **all integrations**. 
* set default values in **fluentd-http** README `override file example`.
* set `Retry_Limit` in **Fluent-bit** to no limit in order for it to keep retrying and not lose any data 
* update **Fluentd** `overflow_action` to 'throw_exception' instead of 'block' 
* set **Fluentd** `flush_thread_count` to 4 for parallelism of the outputs 