### PR TITLE
FIX: add exit status check for the readlink command

### DIFF
--- a/cxtool/cx-integrations
+++ b/cxtool/cx-integrations
@@ -10,6 +10,9 @@ platform=kubernetes
 destination=local
 outputdir=output
 currentPath=$(dirname $(readlink -f $(which cx-integrations)))
+if [ $? -ne 0 ]; then
+  exit 1 
+fi
 
 function main {
 

--- a/cxtool/cx-integrations
+++ b/cxtool/cx-integrations
@@ -11,7 +11,7 @@ destination=local
 outputdir=output
 currentPath=$(dirname $(readlink -f $(which cx-integrations)))
 if [ $? -ne 0 ]; then
-  exit 1 
+  currentPath=. 
 fi
 
 function main {


### PR DESCRIPTION
### Bug Fix:
In case we are running the script within its dir, and not via sym link, the readlink command will fail.
Therefore, in case the readlink command returns exit code 1, Im setting the current path to . instead of the link path 