### PR TITLE
Upgrade Fluentbit image due to a bug in previous version

### DIFF
--- a/fluent-bit/image/Dockerfile
+++ b/fluent-bit/image/Dockerfile
@@ -8,7 +8,7 @@ COPY ./out_coralogix.go ./go.mod ./go.sum ./
 RUN go mod vendor && \
     go build -buildmode=c-shared -ldflags "-s -w" -mod=vendor -o out_coralogix.$TARGETARCH.so .
 
-FROM fluent/fluent-bit:1.9.2
+FROM fluent/fluent-bit:1.9.3
 ARG TARGETARCH
 MAINTAINER Coralogix Inc. <info@coralogix.com>
 LABEL Description="Special Fluent-Bit image for Coralogix integration" Vendor="Coralogix Inc." Version="1.0.0"


### PR DESCRIPTION
Upgrade fluentbit image - in version 1.9.2 there is a bug on `nest filter` that doesnt allow using multiple wildcards as we use in our charts. 
Fixed in 1.9.3