### PR TITLE
Update fluentbit changelog - upgrading fluentbit to 1.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,6 @@
 
 ### v0.0.2 / 2022-04-26
 
-* [UPGRADE] Upgrade Fluent-Bit version to 1.9.2 
+* [UPGRADE] Upgrade Fluent-Bit version to 1.9.3
 * [CHANGE] Set Retry_Limit to False [no limit] to keep retrying send the logs and not lose any data
   ([#48](https://github.com/coralogix/eng-integrations/pull/48))


### PR DESCRIPTION
Upgrading Fluentbit from 1.9.2 to 1.9.3 due to a bug fix. Override the current 0.0.2 release. 