### PR TITLE
FIX: disabling metrics and logs pipeline, update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,26 +31,29 @@ For installation of each integration, please go inside each intergation's direct
 - [Fluentd-HTTP chart](https://github.com/coralogix/eng-integrations/blob/master/fluentd/http/README.md)
 - [Fluent-bit-Coralogix chart](https://github.com/coralogix/eng-integrations/blob/master/fluent-bit/coralogix/README.md)
 - [Fluent-bit-HTTP chart](https://github.com/coralogix/eng-integrations/blob/master/fluent-bit/http/README.md)
+- [OpenTelementry-Agent chart](https://github.com/coralogix/eng-integrations/blob/master/opel-agent/README.md)
 
 ---
 **NOTE**
 
-All integrations require a `secret` called `integrations-privatekey` with the relevant `send your logs` key under a secrey key called `PRIVATE_KEY`,
+All integrations require a `secret` called `integrations-privatekey` with the relevant `private key` under a secrey key called `PRIVATE_KEY`,
 inside the `same namespace` that the chart is installed in.
 
-* The `send-your-logs` key appears under 'Data Flow' --> 'API Keys' in Coralogix UI. 
+* The `private key` appears under 'Data Flow' --> 'API Keys' in Coralogix UI:
+![logo](https://github.com/coralogix/eng-integrations/blob/master/opel-agent/images/dataflow.jpg?raw=true)
+![logo](https://github.com/coralogix/eng-integrations/blob/master/opel-agent/images/key.jpg?raw=true)
 
 ```bash
 kubectl create secret generic integrations-privatekey \
   -n <the-namespace-of-the-release> \
-  --from-literal=PRIVATE_KEY=<send-your-logs-private-key>
+  --from-literal=PRIVATE_KEY=<private-key>
 ```
 
 The created secret should look like this:
 ```yaml
 apiVersion: v1
 data:
-  PRIVATE_KEY: <encrypted-send-your-logs-key>
+  PRIVATE_KEY: <encrypted-private-key>
 kind: Secret
 metadata:
   name: integrations-privatekey

--- a/opel-agent/CHANGELOG.md
+++ b/opel-agent/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## OpenTelemtry-Collector
+
+### v0.0.2 / 2022-08-24
+ 
+* [FIX] Disable logs and metrics pipeline by default 
+* [FIX] Installation command had a wrong configuratin and chart name 
+* [CHANGE] Update the Coralogix private key secret name to match the logs charts required secret name ['coralogix-otel-privatekey' --> 'integrations-privatekey'] 
+  ([#80](https://github.com/coralogix/eng-integrations/pull/80))
+

--- a/opel-agent/Chart.yaml
+++ b/opel-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.57.2
 keywords:
   - OpenTelemetry Collector

--- a/opel-agent/README.md
+++ b/opel-agent/README.md
@@ -44,12 +44,12 @@ If you have Prometheus configured, with the Prometheus operator, it is recommend
 ## Coralogix Endpoints
 
 | Region  | Traces Endpoint
-|---------|------------------------------------------|
-| USA1	  | `tracing-ingress.coralogix.us`           |
-| APAC1   | `tracing-ingress.app.coralogix.in`       |
-| APAC2   | `tracing-ingress.coralogixsg.com`        |
-| EUROPE1 | `tracing-ingress.coralogix.com`          |
-| EUROPE2 | `tracing-ingress.eu2.coralogix.com`      |
+|---------|-----------------------------------------------|
+| USA1	  | `tracing-ingress.coralogix.us:9443`           |
+| APAC1   | `tracing-ingress.app.coralogix.in:9443`       |
+| APAC2   | `tracing-ingress.coralogixsg.com:9443`        |
+| EUROPE1 | `tracing-ingress.coralogix.com:9443`          |
+| EUROPE2 | `tracing-ingress.eu2.coralogix.com:9443`      |
 
 ---
 **NOTE**

--- a/opel-agent/README.md
+++ b/opel-agent/README.md
@@ -8,6 +8,8 @@ The supported receivers are Otel, Zipkin and Jaeger.
 
 ## Installation
 In order to update the environment variables, please create a new yaml file and include *all* of the following envs inside:
+There is an override.yaml file that can be copied under the `examples` directory.
+
 ```yaml
 ---
 #override.yaml:

--- a/opel-agent/exmaples/override.yaml
+++ b/opel-agent/exmaples/override.yaml
@@ -1,0 +1,16 @@
+opentelemetry-collector:
+  extraEnvs:
+  - name: CORALOGIX_PRIVATE_KEY
+    valueFrom:
+      secretKeyRef:
+        name: integrations-privatekey
+        key: PRIVATE_KEY
+  - name: APP_NAME
+    value: production # Can be any other static value
+  - name: KUBE_NODE_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: spec.nodeName
+  - name: CORALOGIX_ENDPOINT
+    value: # <The Coralogix traces ingress endpoint, must be configured>

--- a/opel-agent/exmaples/override.yaml
+++ b/opel-agent/exmaples/override.yaml
@@ -13,4 +13,4 @@ opentelemetry-collector:
         apiVersion: v1
         fieldPath: spec.nodeName
   - name: CORALOGIX_ENDPOINT
-    value: # <The Coralogix traces ingress endpoint, must be configured>
+    value: # Must be filled

--- a/opel-agent/values.yaml
+++ b/opel-agent/values.yaml
@@ -7,7 +7,7 @@ opentelemetry-collector:
   - name: CORALOGIX_PRIVATE_KEY
     valueFrom:
       secretKeyRef:
-        name: coralogix-otel-privatekey
+        name: integrations-privatekey
         key: PRIVATE_KEY
   - name: APP_NAME
     value: production # Can be any static value
@@ -26,7 +26,7 @@ opentelemetry-collector:
         private_key: "${CORALOGIX_PRIVATE_KEY}"
         application_name: "${APP_NAME}"
     receivers:
-      prometheus: null
+      prometheus: null # If you want to enable the prometheusrules/servicemonitor, this line must be deleted, and also the line above ['receivers:']
     processors:
       memory_limiter: null # Will get the k8s resource limits
       k8sattributes:
@@ -38,8 +38,6 @@ opentelemetry-collector:
           - key_regex: '(.*)'
     service:
       pipelines:
-        metrics: null
-        logs: null
         traces:
           exporters:
             - coralogix
@@ -51,6 +49,8 @@ opentelemetry-collector:
             - otlp
             - zipkin
             - jaeger
+        metrics: null
+        logs: null
 
   image: 
     tag: 0.57.2

--- a/opel-agent/values.yaml
+++ b/opel-agent/values.yaml
@@ -22,7 +22,7 @@ opentelemetry-collector:
   config:
     exporters:
       coralogix:
-        endpoint: "${CORALOGIX_ENDPOINT}:9443"
+        endpoint: "${CORALOGIX_ENDPOINT}"
         private_key: "${CORALOGIX_PRIVATE_KEY}"
         application_name: "${APP_NAME}"
     receivers:


### PR DESCRIPTION
## FIXES and UPGRADES:
* **Changed the `pipeline order`** - now metrics and logs are null [disabled] in the pipeline `after the traces section`. By having them before the tracing, the are enabled automatically, so the order affects it.  
* Update `main readme` to include the new otel chart in addition to the fluent charts and add some small fixes
* Update `otel-agent readme`, to get some info from the main readme
* Update the agent `installation command` - after some checks, its impossible to use `--set` to override only specific envs, it requires to set the whole envs in the installation command which is very complicated. 
Therefore, it requires to create an `override.yaml` file which includes all of the envs in order to change an env.
* Update the otel-agent secret to be the same secret as the fluent charts secret, so there is no need now to have two secrets for logs and traces, with the same key inside. 
* Added `CHANGELOG` for the agent 