### PR TITLE
Upgrade opentelemetry collector app and chart version

### DIFF
--- a/opel-agent/CHANGELOG.md
+++ b/opel-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemtry-Collector
 
+### v0.0.3 / 2022-09-06
+
+* [UPRADE] Upgrading chart version from 0.25.0 to 0.30.0
+* [UPRADE] Upgrading app version from 0.57.2 to 0.59.0
+
 ### v0.0.2 / 2022-08-24
  
 * [FIX] Disable logs and metrics pipeline by default 

--- a/opel-agent/Chart.yaml
+++ b/opel-agent/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.2
-appVersion: 0.57.2
+version: 0.0.3
+appVersion: 0.59.0
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent
   - Coralogix
 dependencies:
   - name: opentelemetry-collector
-    version: "0.25.0"
+    version: "0.30.0"
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector

--- a/opel-agent/values.yaml
+++ b/opel-agent/values.yaml
@@ -53,7 +53,7 @@ opentelemetry-collector:
         logs: null
 
   image: 
-    tag: 0.57.2
+    tag: 0.59.0
 
   tolerations: 
     - operator: Exists


### PR DESCRIPTION
Chart updates : 
* Default resources decreased - cpu is now 256m instead of 1core, and memory is now 512Mi instead of 2Gi [we set the limits to ourselves so its ok] 
* they added support for running the collector as a statefulset

App version updates:
* They deprecated some configs that we didnt use , and added some new features, not supposed to affect us and to break something