### PR TITLE
Add binary protocol to jaeger agent

### DIFF
--- a/opel-agent/CHANGELOG.md
+++ b/opel-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v0.0.6 / 2022-09-18
 
-* [CHANGE] Add binary protocol to Jaeger reciever
+* [FEATURE] Add binary protocol to Jaeger reciever
 
 ### v0.0.5 / 2022-09-15
 

--- a/opel-agent/CHANGELOG.md
+++ b/opel-agent/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## OpenTelemtry-Collector
 
-### v0.0.5 / 2022-09-15
+### v0.0.5 / 2022-09-18
+
+* [CHANGE] Add binary protocol to Jaeger reciever
+
+### v0.0.6 / 2022-09-15
 
 * [CHANGE] Enable hostNetwork
 

--- a/opel-agent/CHANGELOG.md
+++ b/opel-agent/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## OpenTelemtry-Collector
 
-### v0.0.5 / 2022-09-18
+### v0.0.6 / 2022-09-18
 
 * [CHANGE] Add binary protocol to Jaeger reciever
 
-### v0.0.6 / 2022-09-15
+### v0.0.5 / 2022-09-15
 
 * [CHANGE] Enable hostNetwork
 

--- a/opel-agent/Chart.yaml
+++ b/opel-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.59.0
 keywords:
   - OpenTelemetry Collector

--- a/opel-agent/values.yaml
+++ b/opel-agent/values.yaml
@@ -38,6 +38,17 @@ opentelemetry-collector:
         extract:
           labels:
           - key_regex: '(.*)'
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:14250
+          thrift_http:
+            endpoint: 0.0.0.0:14268
+          thrift_compact:
+            endpoint: 0.0.0.0:6831
+          thrift_binary:
+            endpoint: 0.0.0.0:6832
     service:
       pipelines:
         traces:

--- a/opel-agent/values.yaml
+++ b/opel-agent/values.yaml
@@ -42,13 +42,9 @@ opentelemetry-collector:
       jaeger:
         protocols:
           grpc:
-            endpoint: 0.0.0.0:14250
           thrift_http:
-            endpoint: 0.0.0.0:14268
           thrift_compact:
-            endpoint: 0.0.0.0:6831
           thrift_binary:
-            endpoint: 0.0.0.0:6832
     service:
       pipelines:
         traces:


### PR DESCRIPTION
Add binary protocol to Jaeger to support nodejs traces , see : https://www.jaegertracing.io/docs/1.23/client-features/
