### PR TITLE
Set default endpoint to jaeger binary protocol

### DIFF
--- a/opel-agent/CHANGELOG.md
+++ b/opel-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v0.0.7 / 2022-09-18
 
-* [FIX] Set the jaeger receiver thrift_binary protocol default endpoint
+* [BUGFIX] Set the jaeger receiver thrift_binary protocol default endpoint
 
 ### v0.0.6 / 2022-09-18
 

--- a/opel-agent/CHANGELOG.md
+++ b/opel-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Collector
 
+### v0.0.7 / 2022-09-18
+
+* [FIX] Set the jaeger receiver thrift_binary protocol default endpoint
+
 ### v0.0.6 / 2022-09-18
 
 * [FEATURE] Add binary protocol to Jaeger reciever

--- a/opel-agent/Chart.yaml
+++ b/opel-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.6
+version: 0.0.7
 appVersion: 0.59.0
 keywords:
   - OpenTelemetry Collector

--- a/opel-agent/values.yaml
+++ b/opel-agent/values.yaml
@@ -45,6 +45,7 @@ opentelemetry-collector:
           thrift_http:
           thrift_compact:
           thrift_binary:
+            endpoint: 0.0.0.0:6832
     service:
       pipelines:
         traces:

--- a/opel-agent/values.yaml
+++ b/opel-agent/values.yaml
@@ -41,9 +41,6 @@ opentelemetry-collector:
     receivers:
       jaeger:
         protocols:
-          grpc:
-          thrift_http:
-          thrift_compact:
           thrift_binary:
             endpoint: 0.0.0.0:6832
     service:


### PR DESCRIPTION
The default endpoint must be set , therefor setting the endpoint for the binary protocol